### PR TITLE
SEARCH-996 Upgrade cxf-rt-transports-http.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>alfresco-data-model</artifactId>
             <version>${dependency.alfresco-data-model.version}</version>
         </dependency>
+        <!-- To avoid the vulnerability in 3.0.10: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6812 -->
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <version>3.0.12</version>
+        </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Whitesource identified a vulnerability in cxf-rt-transports-http 3.0.10 which
is fixed in 3.0.12.