### PR TITLE
[ SEARCH-1286 ] Update alfresco-data-model dep version (8.23 -> 8.24)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </distributionManagement>
 
     <properties>
-        <dependency.alfresco-data-model.version>8.23</dependency.alfresco-data-model.version>
+        <dependency.alfresco-data-model.version>8.24</dependency.alfresco-data-model.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The PR contains the alfresco-data-model dependency version update from 8.23 to 8.24

@tunaaksoy the bamboo build on the source branch is green: https://bamboo.alfresco.com/bamboo/browse/PLAT-DM-129 